### PR TITLE
INFRA-4261 Pin GitHub Actions to specific commit SHA

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -13,17 +13,17 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: terraform-linters/setup-tflint@v2
+    - uses: terraform-linters/setup-tflint@d4316e06e67be17ddca9c400dccf7ef910eef15b
       name: Setup TFLint
       with:
         tflint_version: v0.38.1
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-    - uses: pre-commit/action@v3.0.0
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+    - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236
+    - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
       # pre-commit fails if it changed files
       # we want to go on
       continue-on-error: true
-    - uses: pre-commit/action@v3.0.0
-    - uses: EndBug/add-and-commit@v9
+    - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
+    - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5
       with:
         default_author: github_actions

--- a/.github/workflows/relyance-sci.yml
+++ b/.github/workflows/relyance-sci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Pull and run SCI binary
         run: |-


### PR DESCRIPTION
Requestor/Issue: #incident-216
Tested (yes/no): yes
Description/Why: This pull request includes several updates to various GitHub Actions and workflows to use specific commit SHAs for the actions, ensuring stability and security.