### PR TITLE
fix(provider): datadog >= 3.12 + bump generic-monitor ref to v1.2.0 for v4 compat (INFRA-6827)

### DIFF
--- a/cpu-limits-low-perc-state.tf
+++ b/cpu-limits-low-perc-state.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "cpu_limits_low_perc_state" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Available CPU for Limits in percentages Low"
   query            = "max(${var.cpu_limits_low_perc_state_evaluation_period}):( sum:kubernetes_state.container.cpu_limit{${local.cpu_limits_low_perc_state_filter}} by {host,kube_cluster_name} / sum:kubernetes_state.node.cpu_capacity{${local.cpu_limits_low_perc_state_filter}} by {host,kube_cluster_name}) * 100 > ${var.cpu_limits_low_perc_state_critical}"

--- a/cpu-limits-low-perc.tf
+++ b/cpu-limits-low-perc.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "cpu_limits_low_perc" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Available CPU for Limits in percentages Low"
   query            = "max(${var.cpu_limits_low_perc_evaluation_period}):(sum:kubernetes.cpu.limits{${local.cpu_limits_low_perc_filter}} by {host,kube_cluster_name} / max:system.cpu.num_cores{${local.cpu_limits_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.cpu_limits_low_perc_critical}"

--- a/cpu-limits-low.tf
+++ b/cpu-limits-low.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "cpu_limits_low" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Available CPU for Limits Low"
   query            = "min(${var.cpu_limits_low_evaluation_period}):max:system.cpu.num_cores{${local.cpu_limits_low_filter}} by {kube_cluster_name,host} - sum:kubernetes.cpu.limits{${local.cpu_limits_low_filter}} by {kube_cluster_name,host} < ${var.cpu_limits_low_critical}"

--- a/cpu-on-dns-pods-high.tf
+++ b/cpu-on-dns-pods-high.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 module "cpu_on_dns_pods_high" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "CPU Usage on DNS pods is high"
   query            = "avg(${var.cpu_on_dns_pods_high_evaluation_period}):avg:docker.cpu.usage{${local.cpu_on_dns_pods_high_filter}} by {kube_cluster_name,host,container_name} > ${var.cpu_on_dns_pods_high_critical}"

--- a/cpu-requests-low-perc-state.tf
+++ b/cpu-requests-low-perc-state.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "cpu_requests_low_perc_state" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Available CPU for requests in percentages Low"
   query            = "max(${var.cpu_requests_low_perc_state_evaluation_period}):( sum:kubernetes_state.container.cpu_requested{${local.cpu_requests_low_perc_state_filter}} by {host,kube_cluster_name} / sum:kubernetes_state.node.cpu_capacity{${local.cpu_requests_low_perc_state_filter}} by {host,kube_cluster_name} ) * 100 > ${var.cpu_requests_low_perc_state_critical}"

--- a/cpu-requests-low-perc.tf
+++ b/cpu-requests-low-perc.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "cpu_requests_low_perc" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Available CPU for requests in percentages Low"
   query            = "max(${var.cpu_requests_low_perc_evaluation_period}):100 * sum:kubernetes.cpu.requests{${local.cpu_requests_low_perc_filter}} by {kube_cluster_name,host} / max:system.cpu.num_cores{${local.cpu_requests_low_perc_filter}} by {kube_cluster_name,host} > ${var.cpu_requests_low_perc_critical}"

--- a/cpu-requests-low.tf
+++ b/cpu-requests-low.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "cpu_requests_low" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Available CPU for Requests Low"
   query            = "max(${var.cpu_requests_low_evaluation_period}):max:system.cpu.num_cores{${local.cpu_requests_low_filter}} by {kube_cluster_name,host} - sum:kubernetes.cpu.requests{${local.cpu_requests_low_filter}} by {kube_cluster_name,host} < ${var.cpu_requests_low_critical}"

--- a/daemonset-incomplete.tf
+++ b/daemonset-incomplete.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "daemonset_incomplete" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Daemonset Incomplete"
   query            = "min(${var.daemonset_incomplete_evaluation_period}):max:kubernetes_state.daemonset.scheduled{${local.daemonset_incomplete_filter}} by {kube_daemon_set,kube_cluster_name} - min:kubernetes_state.daemonset.ready{${local.daemonset_incomplete_filter}} by {kube_daemon_set,kube_cluster_name} > 0"

--- a/daemonset-multiple-restarts.tf
+++ b/daemonset-multiple-restarts.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "daemonset_multiple_restarts" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name  = "Daemonset Multiple Restarts"
   query = "max(${var.daemonset_multiple_restarts_evaluation_period}):clamp_min(max:kubernetes.containers.restarts{${local.daemonset_multiple_restarts_filter}} by {kube_daemon_set} - hour_before(max:kubernetes.containers.restarts{${local.daemonset_multiple_restarts_filter}} by {kube_daemon_set}), 0) > ${var.daemonset_multiple_restarts_critical}"

--- a/datadog-agent.tf
+++ b/datadog-agent.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "datadog_agent" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Datadog agent not running"
   query            = "max(${var.datadog_agent_evaluation_period}):avg:datadog.agent.running{${local.datadog_agent_filter}} by {host,kube_cluster_name} < 1"

--- a/deploy-desired-vs-status.tf
+++ b/deploy-desired-vs-status.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "deploy_desired_vs_status" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Desired pods vs current pods (Deployments)"
   query            = "avg(${var.deploy_desired_vs_status_evaluation_period}):max:kubernetes_state.deployment.replicas_desired{${local.deploy_desired_vs_status_filter}} by {kube_cluster_name} - max:kubernetes_state.deployment.replicas_available{${local.deploy_desired_vs_status_filter}} by {kube_cluster_name} > ${var.deploy_desired_vs_status_critical}"

--- a/deployment-multiple-restarts.tf
+++ b/deployment-multiple-restarts.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "deployment_multiple_restarts" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name  = "Deployment Multiple Restarts"
   query = "max(${var.deployment_multiple_restarts_evaluation_period}):clamp_min(max:kubernetes.containers.restarts{${local.deployment_multiple_restarts_filter}} by {kube_deployment} - hour_before(max:kubernetes.containers.restarts{${local.deployment_multiple_restarts_filter}} by {kube_deployment}), 0) > ${var.deployment_multiple_restarts_critical}"

--- a/hpa-status.tf
+++ b/hpa-status.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "hpa_status" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "HPA Status not OK"
   query            = "avg(${var.hpa_status_evaluation_period}):avg:kubernetes_state.hpa.condition{${local.hpa_status_filter}} by {hpa,kube_namespace,status,condition} < 1"

--- a/memory-limits-low-perc-state.tf
+++ b/memory-limits-low-perc-state.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "memory_limits_low_perc_state" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Available Memory for Limits in percentage Low"
   query            = "max(${var.memory_limits_low_perc_state_evaluation_period}):( sum:kubernetes_state.container.memory_limit{${local.memory_limits_low_perc_state_filter}} by {host,kube_cluster_name} / sum:kubernetes_state.node.memory_allocatable{${local.memory_limits_low_perc_state_filter}} by {host,kube_cluster_name}) * 100 > ${var.memory_limits_low_perc_state_critical}"

--- a/memory-limits-low-perc.tf
+++ b/memory-limits-low-perc.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "memory_limits_low_perc" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Available Memory for Limits in percentage Low"
   query            = "max(${var.memory_limits_low_perc_evaluation_period}):( max:kubernetes.memory.limits{${local.memory_limits_low_perc_filter}}  by {host,kube_cluster_name}/ max:system.mem.total{${local.memory_limits_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.memory_limits_low_perc_critical}"

--- a/memory-limits-low.tf
+++ b/memory-limits-low.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "memory_limits_low" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Available Memory for Limits Low"
   query            = "avg(${var.memory_limits_low_evaluation_period}):max:system.mem.total{${local.memory_limits_low_filter}} by {host,kube_cluster_name} - max:kubernetes.memory.limits{${local.memory_limits_low_filter}} by {host,kube_cluster_name} < ${var.memory_limits_low_critical}"

--- a/memory-requests-low-perc-state.tf
+++ b/memory-requests-low-perc-state.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "memory_requests_low_perc_state" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Available Memory for Requests in percentage Low"
   query            = "max(${var.memory_requests_low_perc_state_evaluation_period}):( max:kubernetes_state.container.memory_requested{${local.memory_requests_low_perc_state_filter}} / max:kubernetes_state.node.memory_allocatable{${local.memory_requests_low_perc_state_filter}} ) * 100 > ${var.memory_requests_low_perc_state_critical}"

--- a/memory-requests-low-perc.tf
+++ b/memory-requests-low-perc.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "memory_requests_low_perc" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Available Memory for Requests in percentage Low"
   query            = "max(${var.cpu_requests_low_perc_evaluation_period}):( max:kubernetes.memory.requests{${local.cpu_requests_low_perc_filter}} / max:system.mem.total{${local.cpu_requests_low_perc_filter}} ) * 100 > ${var.cpu_requests_low_perc_critical}"

--- a/memory-requests-low.tf
+++ b/memory-requests-low.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "memory_requests_low" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Available Memory for Requests Low"
   query            = "avg(${var.memory_requests_low_evaluation_period}):max:system.mem.total{${local.memory_requests_low_filter}} by {host,kube_cluster_name} - max:kubernetes.memory.requests{${local.memory_requests_low_filter}} by {host,kube_cluster_name} < ${var.memory_requests_low_critical}"

--- a/network-unavailable.tf
+++ b/network-unavailable.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "network_unavailable" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Nodes with Network Unavailable"
   query            = "avg(${var.network_unavailable_evaluation_period}):max:kubernetes_state.node.by_condition{${local.network_unavailable_filter} AND condition:networkunavailable AND (status:true OR status:unknown)} by {kube_cluster_name,host} > ${var.network_unavailable_critical}"

--- a/node-diskpressure.tf
+++ b/node-diskpressure.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "node_diskpressure" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Nodes with Diskpressure"
   query            = "avg(${var.node_diskpressure_evaluation_period}):max:kubernetes_state.node.by_condition{${local.node_diskpressure_filter} AND condition:diskpressure AND (status:true OR status:unknown)} by {kube_cluster_name,host} > ${var.node_diskpressure_critical}"

--- a/node-memory-used-percent.tf
+++ b/node-memory-used-percent.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "node_memory_used_percent" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Memory Used Percent"
   query            = "avg(${var.node_memory_used_percent_evaluation_period}):( 100 * max:kubernetes.memory.usage{${local.node_memory_used_percent_filter}} by {host,kube_cluster_name} ) / max:system.mem.total{${local.node_memory_used_percent_filter}} by {host,kube_cluster_name} > ${var.node_memory_used_percent_critical}"

--- a/node-memorypressure.tf
+++ b/node-memorypressure.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "node_memorypressure" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Nodes with Memorypressure"
   query            = "avg(${var.node_memorypressure_evaluation_period}):max:kubernetes_state.node.by_condition{${local.node_memorypressure_filter} AND condition:memorypressure AND (status:true OR status:unknown)} by {kube_cluster_name,host} > ${var.node_memorypressure_critical}"

--- a/node-ready.tf
+++ b/node-ready.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "node_ready" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Node Not Ready"
   query            = "avg(${var.node_ready_evaluation_period}):count_nonzero(sum:kubernetes_state.node.by_condition{${local.node_ready_filter} AND (NOT condition:*ready) AND (status:true OR status:unknown)} by {kube_cluster_name,host}) > ${var.node_ready_critical}"

--- a/node-status.tf
+++ b/node-status.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "node_status" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name                = "Node Status not OK"
   query               = "avg(${var.node_status_evaluation_period}):avg:kubernetes_state.node.status{${local.node_status_filter}} by {kube_cluster_name,node} < 1"

--- a/persistent-volumes.tf
+++ b/persistent-volumes.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "persistent_volumes_low" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Failed Persistent Volume Claims"
   query            = "avg(${var.persistent_volumes_evaluation_period}):max:kubernetes_state.persistentvolume.by_phase{${local.persistent_volumes_filter} AND phase:failed} > ${var.persistent_volumes_critical}"

--- a/pid-pressure.tf
+++ b/pid-pressure.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "pid_pressure" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Nodes with PID Pressure"
   query            = "avg(${var.pid_pressure_evaluation_period}):max:kubernetes_state.node.by_condition{${local.pid_pressure_filter} AND condition:pidpressure AND (status:true OR status:unknown)} by {kube_cluster_name,host} > ${var.pid_pressure_critical}"

--- a/pod-count-per-node-high.tf
+++ b/pod-count-per-node-high.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "pod_count_per_node_high" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name  = "Pod count per node high"
   query = "min(${var.pod_count_per_node_high_evaluation_period}):sum:kubernetes.pods.running{${local.pod_count_per_node_high_filter}} by {host} > ${var.pod_count_per_node_high_critical}"

--- a/pod-ready.tf
+++ b/pod-ready.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "pod_ready" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Pod status not ready"
   query            = "min(${var.pod_ready_evaluation_period}):sum:kubernetes_state.pod.count{${local.pod_ready_filter}} by {kube_cluster_name,kube_namespace} - sum:kubernetes_state.pod.ready{${local.pod_ready_filter}} by {kube_cluster_name,kube_namespace} > 0"

--- a/pod-restarts.tf
+++ b/pod-restarts.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "pod_restarts" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Restarting Pods"
   query            = "change(avg(${var.pod_restarts_evaluation_period}),${var.pod_restarts_evaluation_period}):exclude_null(avg:kubernetes.containers.restarts{${local.pod_restarts_filter}} by {pod_name}) > ${var.pod_restarts_critical}"

--- a/pods-failed.tf
+++ b/pods-failed.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "pods_failed" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name  = "Pods Failed"
   query = "min(${var.pods_failed_evaluation_period}):default_zero(max:kubernetes_state.pod.status_phase{phase:failed${var.filter_str_concatenation}${local.pods_failed_filter}} by {kube_namespace}) > ${var.pods_failed_critical}"

--- a/pods-pending.tf
+++ b/pods-pending.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "pods_pending" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name  = "Pods Pending"
   query = "min(${var.pods_pending_evaluation_period}):default_zero(max:kubernetes_state.pod.status_phase{phase:pending${var.filter_str_concatenation}${local.pods_pending_filter}} by {kube_namespace}) > ${var.pods_pending_critical}"

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = "~> 3.12"
+      version = ">= 3.12"
     }
   }
 }

--- a/replicaset-incomplete.tf
+++ b/replicaset-incomplete.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "replicaset_incomplete" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Replicaset Incomplete"
   query            = "min(${var.replicaset_incomplete_evaluation_period}):max:kubernetes_state.replicaset.replicas_desired{${local.replicaset_incomplete_filter}} by {kube_replica_set,kube_cluster_name} - min:kubernetes_state.replicaset.replicas_ready{${local.replicaset_incomplete_filter}} by {kube_replica_set,kube_cluster_name} > ${var.replicaset_incomplete_critical}"

--- a/replicaset-unavailable.tf
+++ b/replicaset-unavailable.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 module "replicaset_unavailable" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name = "Replicaset Unavailable"
   # This (ab)uses a division by zero to make sure we don't get alerts when nr of desired pods < 2

--- a/sts-desired-vs-status.tf
+++ b/sts-desired-vs-status.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "sts_desired_vs_status" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name             = "Desired pods vs current pods (Statefulsets)"
   query            = "avg(${var.sts_desired_vs_status_evaluation_period}):max:kubernetes_state.statefulset.replicas_desired{${local.sts_desired_vs_status_filter}} by {kube_cluster_name} - max:kubernetes_state.statefulset.replicas_ready{${local.sts_desired_vs_status_filter}} by {kube_cluster_name} > ${var.sts_desired_vs_status_critical}"

--- a/sts-multiple-restarts.tf
+++ b/sts-multiple-restarts.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "sts_multiple_restarts" {
-  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.1.0"
+  source = "git@github.com:worldcoin/terraform-datadog-generic-monitor?ref=v1.2.0"
 
   name  = "Statefulset Multiple Restarts"
   query = "max(${var.sts_multiple_restarts_evaluation_period}):clamp_min(max:kubernetes.containers.restarts{${local.sts_multiple_restarts_filter}} by {kube_stateful_set} - hour_before(max:kubernetes.containers.restarts{${local.sts_multiple_restarts_filter}} by {kube_stateful_set}), 0) > ${var.sts_multiple_restarts_critical}"


### PR DESCRIPTION
Requestor/Issue: INFRA-6827
Tested (yes/no): no
Description/Why: 
Widen the Datadog provider range and point all 36 monitor submodule refs at terraform-datadog-generic-monitor v1.2.0 (which carries the widened range). Without the ref bump the transitive v1.1.0 pin would keep capping datadog at ~> 3.12 and block v4 in consumer workspaces. No 'locked' usage; restricted_roles supported on v4.