### PR TITLE
Add terraform dependabot ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,18 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # Maintain Terraform module + provider versions.
+  # terraform-datadog-kubernetes and the module it consumes
+  # (terraform-datadog-generic-monitor) are public git sources, so no
+  # registry/token is required to bump ?ref= tags.
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[terraform] "
+    groups:
+      terraform:
+        patterns:
+          - "*"


### PR DESCRIPTION
Phase 1 of the terraform-module dependabot rollout (INFRA-6819 follow-on). This repo previously had **no** module-update automation (not the cron workflow, not dependabot) yet it consumes `worldcoin/terraform-datadog-generic-monitor` — so its `?ref=` never got bumped.

## Change
Add a `terraform` ecosystem to `.github/dependabot.yml` (weekly, grouped).

## No registry needed
Both this repo and `terraform-datadog-generic-monitor` are **public** git sources, so dependabot resolves and bumps the `?ref=` tags with no registry/secret — same as the validated `terraform-aws-eks` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)